### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ programmers](https://github.com/derek-adair/nflgame/wiki/Tutorial-for-non-progra
 is for you!
 
 Also, nflgame has decent (but not perfect)
-[API documentation](http://pdoc.burntsushi.net/nflgame).
+[API documentation](http://web.archive.org/web/20171205024904/http://pdoc.burntsushi.net:80/nflgame).
 If you're just looking around, make sure to look at the submodules too.
 
 If you need help, please come visit us at IRC/FreeNode on channel `#nflgame`.


### PR DESCRIPTION
Dead API documentation link redirected to the archived version until rehosted(or not). You should also change it in the header of the main page:
![image](https://user-images.githubusercontent.com/6269501/44557652-54d0c800-a6f4-11e8-8562-ccb1c989c5ee.png)

[archived API documentation link](http://web.archive.org/web/20171205024904/http://pdoc.burntsushi.net:80/nflgame)
